### PR TITLE
Adapted README to use with github

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,38 +11,38 @@ Install prerequisites
 
 Getting the homepage to run locally is best supported using virtualenv and
 pip. Install those two tools first, either via easy_install or via your local
-package manager. You will also need development tools (gcc or therelike), hg
-(mercurial), bzr, subversion and git. Finally you are going to need the
-build dependencies for numpy, which will be compiled as a part of getting
-the dependencies for the website. Go and install them all.
+package manager. You will also need development tools, subversion or git.
+Finally you are going to need the build dependencies for numpy, which will be
+compiled as a part of getting the dependencies for the website.
+Go and install them all.
 
 Example:
-On Ubuntu, installing all required tools and dependencies in two commands:
+On Ubuntu, installing all required tools and dependencies in two commands::
 
-   $ sudo apt-get install python3-virtualenv python3-pip bzr libmysqlclient-dev
-   $ sudo apt-get build-dep python3-numpy
+   sudo apt-get install python3-virtualenv python3-pip git subversion libmysqlclient-dev
+   sudo apt-get build-dep python3-numpy
 
 Setting up the local environment
 --------------------------------
 
-Go to the directory you want to install the homepage to, then run:
+Go to the directory you want to install the homepage to, then run::
 
-   $ export PYTHONPATH=
+   export PYTHONPATH=
 
 This will make sure that your virtual environment is not tainted with python
 packages from your global site packages. Very important!
-Now, we create and activate our environment:
+Now, we create and activate our environment::
 
-   $ virtualenv --python=python3.6 wlwebsite
-   $ cd wlwebsite
-   $ source bin/activate
+   virtualenv --python=python3.6 wlwebsite
+   cd wlwebsite
+   source bin/activate
 
 Next, we download the website source code::
 
-   $ mkdir code
-   $ cd code
-   $ bzr branch lp:widelands-website widelands
-   $ cd widelands
+   mkdir code
+   cd code
+   git clone https://github.com/widelands/widelands-website.git widelands
+   cd widelands
 
 All fine and good. Now we have to install all the third party modules the
 website needs. We use pip for that.
@@ -53,7 +53,7 @@ PIL and numpy; you can also try to migrate them over from your global site dir
 or add your global site dir to your PYTHONPATH.
 Installation via pip should work like this::
 
-   $ pip install -r pip_requirements.txt
+   pip install -r pip_requirements.txt
 
 This will take a while. If no errors are shown we should be fine.
 
@@ -69,24 +69,24 @@ local_urls.py.sample to settings_local.py and local_urls.py. Take a look at
 those files and modify them to your needs - most likely everything works
 directly, but you might want to edit the bd variable in local_settings.py::
 
-   $ ln -s local_urls.py.sample mainpage/local_urls.py
-   $ ln -s local_settings.py.sample mainpage/local_settings.py
+   ln -s local_urls.py.sample mainpage/local_urls.py
+   ln -s local_settings.py.sample mainpage/local_settings.py
 
 Setting up the database
 -----------------------
 
-Now creating the tables in the database:
+Create the tables in the database::
 
-   $ ./manage.py migrate
-   $ ./manage.py createcachetable
+   ./manage.py migrate
+   ./manage.py createcachetable
 
 Create a superuser:
 
-   $ ./manage.py createsuperuser
+   ./manage.py createsuperuser
 
 Now, let's run the page::
 
-   $ ./manage.py runserver
+   ./manage.py runserver
 
 Open your browser to http://localhost:8000. You should see something that
 resembles the widelands homepage quite closely. All content is missing though.
@@ -95,18 +95,17 @@ Some important settings
 -----------------------
 
 Go to http://localhost:8000/admin. Log in with your super user and go to the
-following table:
-
-- Site/Sites: Change your site name from example.com to localhost:8000.
+section "Site->Sites" and change your site name from example.com to
+localhost:8000.
 
 Now everything should work.
 
 Runnning with DBUG=False
 ------------------------
 In case you want to test the site with the setting DEBUG=False, you might
-notice that at least the admin site is missing all css. To fix this run:
+notice that at least the admin site is missing all css. To fix this run::
 
-  $ ./manage.py collectstatic -l
+  ./manage.py collectstatic -l
 
 This will create symbolic links (-l) to static contents of third party apps in
 the folder defined by STATIC_ROOT. See:
@@ -115,15 +114,7 @@ https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#collectstatic
 Accessing the website from other machines
 -----------------------------------------
 
-When starting the server as described above, the website will by default
-only be available from the machine it is running on. If you wish to access
-the website from other machines you need to specify an IP-address and
-port number. Please note, however, that this server is NOT intended for
-production environments, only for development/testing.
-
-   $ ./manage.py runserver 169.254.1.0:8000
-
-See also https://docs.djangoproject.com/en/dev/ref/django-admin/#examples-of-using-different-ports-and-addresses
+See https://docs.djangoproject.com/en/dev/ref/django-admin/#examples-of-using-different-ports-and-addresses
 for further details.
 
 
@@ -138,16 +129,16 @@ Source code only
 
 The documentation is made out of the source code. To get a copy, see:
 
-https://wl.widelands.org/wiki/BzrPrimer/
+https://wl.widelands.org/wiki/GitPrimer/
 
 After the source code is downloaded, adjust the path of 
 
 WIDELANDS_SVN_DIR = '/path/to/widelands/trunk'
 
 in mainpage/local_settings.py to the path where the widelands source code can be
-found. Then run:
+found. Then run::
 
-   $ ./manage.py create_docs
+   ./manage.py create_docs
 
 After finishing without errors, type localhost:8000/documentation/index.html
 in your browsers addressbar or click on "Development -> Documentation".
@@ -161,25 +152,26 @@ Widelands executables are needed to:
 * Create the Encylopdia
 
 Either install widelands as a program to your operating system, or create the 
-binaries by compiling the source code. If you want to compile, run:
+binaries by compiling the source code. If you want to compile, run::
 
-   $ ./compile.sh -r
+   ./compile.sh -r
 
 inside of the WIDELANDS_SVN_DIR to create a release build.
 
 Uploading maps should work now.
 
-Creating the encyclopdia needs graphviz to generate the graphs. On Ubuntu run:
+Creating the encyclopdia needs graphviz to generate the graphs. On Ubuntu run::
 
-   $ sudo apt-get install graphviz
+   sudo apt-get install graphviz
 
-To generate the online help switch to your local environment and run:
+To generate the online help switch to the local environment of the website
+and run::
 
-   $ ./manage.py update_help
+   ./manage.py update_help
 
-Now you can create the economy graphs:
+Now you can create the economy graphs::
 
-   $ ./manage.py update_help_pdf
+   ./manage.py update_help_pdf
 
 You can access the encyclopdia by clicking on 'The Game -> Encyclopedia' now.
 
@@ -188,6 +180,3 @@ Contact
 =======
 
 Contact user 'kaputtnik' on the homepage for more information and problems.
-
-
--- vim:ft=rst:

--- a/README.txt
+++ b/README.txt
@@ -80,7 +80,7 @@ Create the tables in the database::
    ./manage.py migrate
    ./manage.py createcachetable
 
-Create a superuser:
+Create a superuser::
 
    ./manage.py createsuperuser
 

--- a/README.txt
+++ b/README.txt
@@ -180,3 +180,5 @@ Contact
 =======
 
 Contact user 'kaputtnik' on the homepage for more information and problems.
+
+-- vim:ft=rst:


### PR DESCRIPTION
Not sure if we want the README.txt to show here on github on the frontpage.

Maybe better is to provide a README.md which will be much shorter (short description), but contain the license. As far i understand github will pick the README.md for the frontpage if the file exists.