### PR TITLE
Hide deleted users

### DIFF
--- a/pybb/templates/pybb/inlines/post.html
+++ b/pybb/templates/pybb/inlines/post.html
@@ -10,8 +10,10 @@
 
 <td class="author">
 	{{ post.user|user_link }}<br />
-	{% if not post.user.wlprofile.deleted %}
-		{% if post.user.wlprofile.avatar %}
+	{% if post.user.wlprofile.avatar %}
+		{% if post.user.wlprofile.deleted %}
+			<img src="{{ post.user.wlprofile.avatar.url }}" alt="Avatar" />
+		{% else %}
 			<a href="{% url 'profile_view' post.user %}">
 				<img src="{{ post.user.wlprofile.avatar.url }}" alt="Avatar" />
 			</a>

--- a/pybb/templates/pybb/inlines/post.html
+++ b/pybb/templates/pybb/inlines/post.html
@@ -10,10 +10,12 @@
 
 <td class="author">
 	{{ post.user|user_link }}<br />
-	{% if post.user.wlprofile.avatar %}
-	<a href="{% url 'profile_view' post.user %}">
-		<img src="{{ post.user.wlprofile.avatar.url }}" alt="Avatar" />
-	</a>
+	{% if not post.user.wlprofile.deleted %}
+		{% if post.user.wlprofile.avatar %}
+			<a href="{% url 'profile_view' post.user %}">
+				<img src="{{ post.user.wlprofile.avatar.url }}" alt="Avatar" />
+			</a>
+		{% endif %}
 	{% endif %}
 	<div class="authorStats">
 	<strong>Joined:</strong> {{ post.user.date_joined|custom_date:user|title }}<br />

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -508,10 +508,13 @@ all_latest = render_to('pybb/all_last_posts.html')(all_latest_posts)
 def all_user_posts(request, this_user=None):
     """Get all posts of a user"""
 
-    if this_user:
-        posts = Post.objects.public().filter(user__username=this_user)
-    else:
+    if this_user is None:
         posts = Post.objects.public().filter(user__username=request.user)
+    else:
+        if get_object_or_404(User, username=this_user).wlprofile.deleted:
+            raise Http404("User has been deleted")
+
+        posts = Post.objects.public().filter(user__username=this_user)
 
     return {
         'this_user': this_user,

--- a/wlprofile/views.py
+++ b/wlprofile/views.py
@@ -117,6 +117,9 @@ def view(request, user=None):
     else:
         profile = get_object_or_404(User, username=user).wlprofile
 
+    if profile.deleted:
+        raise Http404("User has been deleted")
+
     template_params = {
         'profile': profile,
     }


### PR DESCRIPTION
-  Raise 404 instead of showing deleted profile pages 
-  Don't show list of posts for non-existent or deleted users 
-  Hide avatar in posts of deleted users 