### PR TITLE
Map min version glitch

### DIFF
--- a/wlmaps/templates/wlmaps/inlines/version_info.html
+++ b/wlmaps/templates/wlmaps/inlines/version_info.html
@@ -1,9 +1,10 @@
 <strong>This map requires a version of Widelands
     {% if map.wl_version_after %}
     	{% if not 'build' in map.wl_version_after and not '.' in map.wl_version_after %}
-    		build
+    		build {{ map.wl_version_after|add:1 }}
+    	{% else %}
+    		{{ map.wl_version_after }}
     	{% endif %}
-    	{{ map.wl_version_after }}
     {% else %}
     	{% if map.nr_players > 8 %}
     		build 20


### PR DESCRIPTION
Ups…
I just noticed that all maps on the homepage that need a version *after build 20* are now shown as **needs build 20 or newer*. I guess that this should fix it (don't know how I could test this though?)