### PR TITLE
adjusted css for the documentation

### DIFF
--- a/documentation/styles/basic.css
+++ b/documentation/styles/basic.css
@@ -408,8 +408,12 @@ table.field-list td, table.field-list th {
     padding-left: 1em;
 }
 
-.field-list p {
+/*.field-list p {
     margin: 0;
+}*/
+
+ul p {
+   margin: 0;
 }
 
 .field-name {

--- a/documentation/styles/basic.css
+++ b/documentation/styles/basic.css
@@ -353,10 +353,6 @@ table.docutils td, table.docutils th {
     border-bottom: 1px solid #aaa;
 }
 
-table.docutils tr.row-even {
-   background-color: #424242;
-}
-
 table.docutils p {
    margin: 0 0 2px 0;
 }

--- a/documentation/styles/basic.css
+++ b/documentation/styles/basic.css
@@ -341,12 +341,24 @@ table caption span.caption-number {
 table caption span.caption-text {
 }
 
+table.docutils tr {
+   vertical-align: top;
+}
+
 table.docutils td, table.docutils th {
     padding: 1px 8px 1px 5px;
     border-top: 0;
     border-left: 0;
     border-right: 0;
     border-bottom: 1px solid #aaa;
+}
+
+table.docutils tr.row-even {
+   background-color: #424242;
+}
+
+table.docutils p {
+   margin: 0 0 2px 0;
 }
 
 table.footnote td, table.footnote th {

--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -214,6 +214,7 @@ pre {
 div.body code .pre {
    background-image: url("black20.png");
    padding: 0 1px 0 1px;
+   font-size: 1.1em;
 }
 
 th {

--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -217,8 +217,20 @@ div.body code .pre {
    font-size: 1.1em;
 }
 
-th {
+table.docutils thead tr {
    background-image: url("black20.png");
+}
+
+table.docutils caption {
+    text-align: left;
+    font-size: 1.2em;
+    font-weight: bold;
+    color: #181;
+    margin: 2px;
+}
+
+table.docutils tr.row-even {
+   background-color: #424242;
 }
 
 .warning code {

--- a/wlmaps/templates/wlmaps/map_list.html
+++ b/wlmaps/templates/wlmaps/map_list.html
@@ -52,8 +52,10 @@
 
 <div class="blogEntry">
 	<p>
-	NOTE: Uploading maps on the website which use terrains from add-ons will not work! Starting with Widelands version 1.0 it is recommended to upload new maps within the game,
-	especially if some World add-ons are installed.	
+	  <span class="errormessage">Please note:</span> Uploading maps on the website which use terrains
+	  from add-ons will not work! Starting with Widelands version 1.0 it is recommended to upload new
+	  maps within the game as an add-on. To do so start the "Add-Ons Packager" via 
+	  "Main menu → Add-Ons → Tab Development → Launch the add-ons packager".
 	</p>
 	<p>
 	The map files have to be placed in the Widelands map directory to be found by the game. Check the <a href="/wiki/Technical%20FAQ/#where-are-my-maps-and-savegames-stored">Technical FAQ</a> to find the map directory.

--- a/wlmaps/templates/wlmaps/map_list.html
+++ b/wlmaps/templates/wlmaps/map_list.html
@@ -52,6 +52,10 @@
 
 <div class="blogEntry">
 	<p>
+	NOTE: Uploading maps on the website which use terrains from add-ons will not work! Starting with Widelands version 1.0 it is recommended to upload new maps within the game,
+	especially if some World add-ons are installed.	
+	</p>
+	<p>
 	The map files have to be placed in the Widelands map directory to be found by the game. Check the <a href="/wiki/Technical%20FAQ/#where-are-my-maps-and-savegames-stored">Technical FAQ</a> to find the map directory.
 	</p>
 

--- a/wlmaps/templates/wlmaps/upload.html
+++ b/wlmaps/templates/wlmaps/upload.html
@@ -15,6 +15,12 @@
 	<div class="breadCrumb">
 		<a href="{% url 'wlmaps_index' %}">Maps</a> &#187; Upload
 	</div>
+	<p>
+	  <span class="errormessage">Please note:</span> Uploading maps on the website which use terrains
+	  from add-ons will not work! Starting with Widelands version 1.0 it is recommended to upload new
+	  maps within the game as an add-on. To do so start the "Add-Ons Packager" via 
+	  "Main menu → Add-Ons → Tab Development → Launch the add-ons packager".
+	</p>
 	<form enctype="multipart/form-data" action="{% url 'wlmaps_upload' %}" method="post">
 		{{ form.file.label_tag }} {{ form.file }}<br />
 		{% if form.file.errors %}


### PR DESCRIPTION
Make text in pre tags a bit bigger, because they were smaller than normal text (above is the old size)

![documentation-css-1](https://user-images.githubusercontent.com/6730556/119232877-0eb82580-bb27-11eb-8812-1190ff5aa433.png)

Changes to tables:

* less height for table cells
* coloring for rows

![documentation-css-2](https://user-images.githubusercontent.com/6730556/119233037-6e163580-bb27-11eb-954f-782fdda6d841.png)

Compare with [modify_unit](https://www.widelands.org/documentation/autogen_wl/#wl.Descriptions.modify_unit)