### PR TITLE
Lua class graphs (website)

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -26,7 +26,7 @@
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.mathjax']
+extensions = ['sphinx.ext.mathjax', 'sphinx.ext.graphviz', 'sphinx.ext.inheritance_diagram']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -169,3 +169,4 @@ html_use_index = True
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Widelandsdoc'
+graphviz_output_format = 'svg'

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -26,7 +26,7 @@
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.mathjax', 'sphinx.ext.graphviz', 'sphinx.ext.inheritance_diagram']
+extensions = ['sphinx.ext.mathjax', 'sphinx.ext.graphviz']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/management/commands/create_docs.py
+++ b/documentation/management/commands/create_docs.py
@@ -119,7 +119,7 @@ class Command(BaseCommand):
 
         try:
             check_call(['python', os.path.join(
-                self.sphinx_dir, 'extract_rst.py')])
+                self.sphinx_dir, 'extract_rst.py'), '-graphs'])
             check_call(['sphinx-build',
                         '-b', builder,
                         '-d', os.path.join(self.sphinx_dir, 'build/doctrees'),

--- a/documentation/styles/pygments.css
+++ b/documentation/styles/pygments.css
@@ -3,6 +3,7 @@
 /*******************************/
 pre {
    margin: 4px;
+   display: block; /*show black background over the whole width*/
 }
 .highlight {
    /*	text-shadow: none;
@@ -12,7 +13,6 @@ pre {
     background-image: url("black20.png");
     margin: 4px 0px;
     margin-left: 1em;
-    overflow: auto;
 }
 .highlight .hll { background-color: #ffffcc }
 /*.highlight  { background: #f0f0f0; }*/

--- a/documentation/styles/pygments.css
+++ b/documentation/styles/pygments.css
@@ -3,7 +3,6 @@
 /*******************************/
 pre {
    margin: 4px;
-   display: block; /*show black background over the whole width*/
 }
 .highlight {
    /*	text-shadow: none;
@@ -13,6 +12,7 @@ pre {
     background-image: url("black20.png");
     margin: 4px 0px;
     margin-left: 1em;
+    overflow: auto;
 }
 .highlight .hll { background-color: #ffffcc }
 /*.highlight  { background: #f0f0f0; }*/

--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -106,6 +106,11 @@ div.sphinxsidebar input {
    font-size: 1em;
 }
 
+div.section {
+    min-height: 100px;
+    overflow: hidden;
+}
+
 /* -- hyperlink styles ------------------------------------------------------ */
 
 a {
@@ -135,7 +140,7 @@ div.body h6 {
    font-weight: normal;
    color: #181;
    border-bottom: 1px solid #C8BE93;
-   margin: 20px -20px 10px -20px;
+/*    margin: 20px -20px 10px -20px; */
    padding: 3px 0 3px 10px;
 }
 

--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -256,3 +256,8 @@ table.indextable tr.cap {
   background-image: url("black20.png");
 }
 
+/*--------- graphviz styles --------*/
+
+div.graphviz {
+   float: right;
+}

--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -108,7 +108,8 @@ div.sphinxsidebar input {
 
 div.section {
     min-height: 100px;
-    overflow: hidden;
+    /*overflow: hidden;*/
+    clear: both;
 }
 
 /* -- hyperlink styles ------------------------------------------------------ */
@@ -140,7 +141,7 @@ div.body h6 {
    font-weight: normal;
    color: #181;
    border-bottom: 1px solid #C8BE93;
-/*    margin: 20px -20px 10px -20px; */
+   margin: 20px -20px 10px -20px;
    padding: 3px 0 3px 10px;
 }
 


### PR DESCRIPTION
This is the counterpart to [lua class graphs](https://github.com/widelands/widelands/pull/4960)

* Add command line switch `-graphs` to the management command `create_docs`
* Some css tweaks to get the class inheritance graphs on the right

Scroll [lua class graphs](https://github.com/widelands/widelands/pull/4960) for some example images and created html files.