### PR TITLE
added media query

### DIFF
--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -284,6 +284,11 @@ table.indextable tr.cap {
 
 div.graphviz {
    float: right;
-   max-width: 80%;
 }
 
+@media (max-width: 80em) {
+  div.graphviz {
+    float: none;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
Added media query to let svg-images not destroy text layout depending on the width of the screen of browsers:

If the browsers window get too small, text is shown below the svg-image and the image get centered.