### PR TITLE
Fix bug around wlggz passwords now containing b''

### DIFF
--- a/wlggz/models.py
+++ b/wlggz/models.py
@@ -32,7 +32,7 @@ class GGZAuth(models.Model):
     def save(self, *args, **kwargs):
         # hash the password
         pw_hash = hashlib.sha1(self.password.encode("utf-8")).digest()
-        pw_base64 = base64.standard_b64encode(pw_hash)
+        pw_base64 = base64.standard_b64encode(pw_hash).decode("ascii")
         self.password = pw_base64
         # Save into the database
         super(GGZAuth, self).save(*args, **kwargs)


### PR DESCRIPTION
Problem is that b64encode now returns a byte object that needs to be decoded into a string before being saved into the database.