### PR TITLE
Wiki tagging

### DIFF
--- a/mainpage/settings.py
+++ b/mainpage/settings.py
@@ -174,6 +174,8 @@ PASSWORD_HASHERS = [
 WIKI_LOCK_DURATION = 30
 WIKI_URL_RE = r"[:\-\w ]+"
 WIKI_WORD_RE = r"[:\-\w ]+"
+# List pages below the URL '/wiki/...' here if they are dynamically created
+WIKI_SPECIAL_PAGES = ["list", "search", "history", "feeds", "observe", "edit", "tag_list"]
 
 ######################
 # User configuration #

--- a/mainpage/settings.py
+++ b/mainpage/settings.py
@@ -175,7 +175,15 @@ WIKI_LOCK_DURATION = 30
 WIKI_URL_RE = r"[:\-\w ]+"
 WIKI_WORD_RE = r"[:\-\w ]+"
 # List pages below the URL '/wiki/...' here if they are dynamically created
-WIKI_SPECIAL_PAGES = ["list", "search", "history", "feeds", "observe", "edit", "tag_list"]
+WIKI_SPECIAL_PAGES = [
+    "list",
+    "search",
+    "history",
+    "feeds",
+    "observe",
+    "edit",
+    "tag_list",
+]
 
 ######################
 # User configuration #

--- a/mainpage/settings.py
+++ b/mainpage/settings.py
@@ -203,12 +203,14 @@ EDIT_HOURS = 24
 ####################
 # threadedcomments #
 ####################
-
 DEFAULT_MARKUP = 1  # "markdown"
+
 ##################
 # django-tagging #
 ##################
 FORCE_LOWERCASE_TAGS = True
+MAX_TAG_LENGTH = 20
+
 ##################################
 # Uploading files and validation #
 ##################################

--- a/mainpage/settings.py
+++ b/mainpage/settings.py
@@ -203,7 +203,10 @@ EDIT_HOURS = 24
 ####################
 
 DEFAULT_MARKUP = 1  # "markdown"
-
+##################
+# django-tagging #
+##################
+FORCE_LOWERCASE_TAGS = True
 ##################################
 # Uploading files and validation #
 ##################################

--- a/mainpage/templatetags/wl_markdown.py
+++ b/mainpage/templatetags/wl_markdown.py
@@ -142,7 +142,7 @@ def _classify_link(tag):
             return
 
         # Wiki special pages are also not counted
-        if article_name in ["list", "search", "history", "feeds", "observe", "edit"]:
+        if article_name in settings.WIKI_SPECIAL_PAGES:
             tag["class"] = "specialLink"
             return
 

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -13,7 +13,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKey
 
 from tagging.fields import TagField
-from tagging.models import Tag
+
 from wlimages.models import Image
 
 try:

--- a/wiki/static/css/wiki.css
+++ b/wiki/static/css/wiki.css
@@ -9,7 +9,7 @@
 	float: right;
 	max-width: 20em;
 }
-		
+
 .toc ul {
 	padding-left: 1.8em;
 }
@@ -59,7 +59,7 @@
 	text-align: left;
 }
 
-#edit_wiki_page_form #id_title,#id_comment {
+#edit_wiki_page_form #id_title, #id_comment, #id_tags {
 	width: 100%;
 }
 

--- a/wiki/templates/wiki/edit.html
+++ b/wiki/templates/wiki/edit.html
@@ -16,19 +16,19 @@
 
 	$(document).ready(function() {
 		// Insert rendered markup for preview
-		$("#id_preview").click(function(){ 
+		$("#id_preview").click(function(){
 			// Activate preview
 			$("#preview").html("<h3>Preview</h3>\n<hr>\n<div class=\"wiki_article\" id=\"content_preview\">Loading...</div>\n<hr>");
-			$("#content_preview").load( "{% url 'wiki_preview' %}", 
+			$("#content_preview").load( "{% url 'wiki_preview' %}",
 				{"body": $("#id_content").val()});
 		});
 
-	{% ifequal new_article 0 %} 
-		// Insert diff  
-		$("#id_diff").click(function(){ 
+	{% ifequal new_article 0 %}
+		// Insert diff
+		$("#id_diff").click(function(){
 			// Activate preview
 			$("#diff").html("<h3>Diff</h3>\n<hr>\n<div id=\"content_diff\">Loading...</div>\n<hr>");
-			$("#content_diff").load( "{% url 'wiki_preview_diff' %}", 
+			$("#content_diff").load( "{% url 'wiki_preview_diff' %}",
 				{"body": $("#id_content").val(), "article": {{ object_id }} });
 		});
 	{%endifequal%}
@@ -70,6 +70,8 @@
 			<!-- Content -->
 			<tr><th colspan="2"><label for="id_content">{% trans "Content" %}:</label></th></tr>
 			<tr><td colspan="2"  class="errormessage">{{ form.content.errors }}{{ form.content }}</td></tr>
+			<tr><th colspan="2"><label for={{ form.tags.id_for_label }}>Tags:</label></th></tr>
+			<tr><td colspan="2"  class="errormessage">{{ form.tags.errors }}{{ form.tags }}</td></tr>
 			<!-- Summary -->
 			<tr><th colspan="2"><label for="id_summary">{% trans "Page Summary" %}:</label></th></tr>
 			<tr><td colspan="2"  class="errormessage">{{ form.summary.errors }}{{ form.summary }}</td></tr>
@@ -91,7 +93,7 @@
 			<input type="submit" value="{% trans "Save" %}" />
 		</div>
 		{% csrf_token %}
-	</form> 
+	</form>
 	<br />
 	<h3>Images</h3>
 	{% if new_article %}

--- a/wiki/templates/wiki/edit.html
+++ b/wiki/templates/wiki/edit.html
@@ -72,7 +72,15 @@
 			<tr><th colspan="2"><label for="id_content">{% trans "Content" %}:</label></th></tr>
 			<tr><td colspan="2"  class="errormessage">{{ form.content.errors }}{{ form.content }}</td></tr>
 			<!-- Tags -->
-			<tr><th colspan="2"><label for={{ form.tags.id_for_label }}>Tags:</label></th></tr>
+			<tr>
+				<th colspan="2">
+					<label for={{ form.tags.id_for_label }}>Tags:</label>
+					<a href="/wiki/WikiHelp/#tagging" title="Help (new window)" style="float: right;" target="_blank">
+						<img src="{% static "img/menu_help_borderless.png" %}" alt="Help for tags" class="middle">
+						Help for Tags
+					</a>
+				</th>
+			</tr>
 			<tr><td colspan="2"  class="errormessage">{{ form.tags.errors }}{{ form.tags }}</td></tr>
 			<!-- Summary -->
 			<tr><th colspan="2"><label for="id_summary">{% trans "Page Summary" %}:</label></th></tr>

--- a/wiki/templates/wiki/edit.html
+++ b/wiki/templates/wiki/edit.html
@@ -54,6 +54,7 @@
 	{% endif %}
 	<p>
 	You can edit the wiki pages contents using the syntax described on the <a href="/wiki/WikiSyntax">WikiSyntax</a>.
+	For a description of the input fields see: <a href="/wiki/WikiHelp">WikiHelp</a>
 	</p>
 
 	<div id="preview"></div>
@@ -70,6 +71,7 @@
 			<!-- Content -->
 			<tr><th colspan="2"><label for="id_content">{% trans "Content" %}:</label></th></tr>
 			<tr><td colspan="2"  class="errormessage">{{ form.content.errors }}{{ form.content }}</td></tr>
+			<!-- Tags -->
 			<tr><th colspan="2"><label for={{ form.tags.id_for_label }}>Tags:</label></th></tr>
 			<tr><td colspan="2"  class="errormessage">{{ form.tags.errors }}{{ form.tags }}</td></tr>
 			<!-- Summary -->

--- a/wiki/templates/wiki/index.html
+++ b/wiki/templates/wiki/index.html
@@ -1,7 +1,6 @@
 {% extends "wiki/base.html" %}
 {% load i18n %}
 {% load custom_date wlprofile_extras %}
-{% load tagging_tags %}
 
 {% block title %}Wiki Index - {{ block.super }}{% endblock %}
 
@@ -11,10 +10,6 @@
 
 {% block content_main %}
 <div class="blogEntry">
-	{% tag_cloud_for_model wiki.Article as cloud_tags %}
-	{% for tag in cloud_tags %}
-		<a href="{% url 'article_tag_detail' tag.name %}">{{tag.name}}</a></br>
-	{% endfor %}
 	{% if articles %}
 		<p> There are {{ articles|length }} articles in this wiki:</p>
 		<table>
@@ -23,7 +18,7 @@
 				<th>{% trans "Page" %}</th>
 				<th>{% trans "Summary" %}</th>
 				<th>{% trans "Last update" %}</th>
-				<th>{% trans "Tags" %}</th>
+				<th>{% trans "Tagged with" %}</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/wiki/templates/wiki/index.html
+++ b/wiki/templates/wiki/index.html
@@ -1,6 +1,7 @@
 {% extends "wiki/base.html" %}
 {% load i18n %}
 {% load custom_date wlprofile_extras %}
+{% load tagging_tags %}
 
 {% block title %}Wiki Index - {{ block.super }}{% endblock %}
 
@@ -10,6 +11,10 @@
 
 {% block content_main %}
 <div class="blogEntry">
+	{% tag_cloud_for_model wiki.Article as cloud_tags %}
+	{% for tag in cloud_tags %}
+		<a href="{% url 'article_tag_detail' tag.name %}">{{tag.name}}</a></br>
+	{% endfor %}
 	{% if articles %}
 		<p> There are {{ articles|length }} articles in this wiki:</p>
 		<table>
@@ -18,6 +23,7 @@
 				<th>{% trans "Page" %}</th>
 				<th>{% trans "Summary" %}</th>
 				<th>{% trans "Last update" %}</th>
+				<th>{% trans "Tags" %}</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -26,6 +32,7 @@
 				<td><a href="{% url 'wiki_article' article.title %}">{{ article.title }}</a></td>
 				<td>{{ article.summary }}</td>
 				<td>{{ article.last_update|custom_date:user }}</td>
+				<td>{% include "wiki/inlines/tag_urls.html" %}</td>
 			</tr>
 			{% endfor %}
 		</tbody>

--- a/wiki/templates/wiki/inlines/tag_urls.html
+++ b/wiki/templates/wiki/inlines/tag_urls.html
@@ -1,0 +1,8 @@
+{% load tagging_tags %}
+
+{% tags_for_object article as tag_list %}
+   {% for t in tag_list %}
+	  {% if t != tag %}
+	     <a href="{% url 'article_tag_detail' t.name %}">{{t.name}}</a>
+	  {% endif %}
+   {% endfor %}

--- a/wiki/templates/wiki/inlines/tag_urls.html
+++ b/wiki/templates/wiki/inlines/tag_urls.html
@@ -1,8 +1,8 @@
 {% load tagging_tags %}
 
 {% tags_for_object article as tag_list %}
-   {% for t in tag_list %}
-	  {% if t != tag %}
+	{% for t in tag_list %}
+		{% if t != tag %}
 			<a href="{% url 'article_tag_detail' t.name %}">{{t.name}}</a>{% if not forloop.last %},{% endif %}
-	  {% endif %}
+		{% endif %}
    {% endfor %}

--- a/wiki/templates/wiki/inlines/tag_urls.html
+++ b/wiki/templates/wiki/inlines/tag_urls.html
@@ -3,6 +3,6 @@
 {% tags_for_object article as tag_list %}
    {% for t in tag_list %}
 	  {% if t != tag %}
-	     <a href="{% url 'article_tag_detail' t.name %}">{{t.name}}</a>
+			<a href="{% url 'article_tag_detail' t.name %}">{{t.name}}</a>{% if not forloop.last %},{% endif %}
 	  {% endif %}
    {% endfor %}

--- a/wiki/templates/wiki/inlines/tag_urls.html
+++ b/wiki/templates/wiki/inlines/tag_urls.html
@@ -3,6 +3,9 @@
 {% tags_for_object article as tag_list %}
 	{% for t in tag_list %}
 		{% if t != tag %}
+		{% comment %}the forloop.last needs to be in every line to prevent a space after the tag {% endcomment %}
 			<a href="{% url 'article_tag_detail' t.name %}">{{t.name}}</a>{% if not forloop.last %},{% endif %}
+		{% else %}
+			<span class="grey">{{ t.name }}</span>{% if not forloop.last %},{% endif %}
 		{% endif %}
    {% endfor %}

--- a/wiki/templates/wiki/tag_view.html
+++ b/wiki/templates/wiki/tag_view.html
@@ -1,0 +1,34 @@
+{% extends 'wiki/base.html' %}
+{% load i18n %}
+{% load wiki_extras %}
+
+{% block title %}
+{{ article.title }} - {{block.super}}
+{% endblock %}
+
+
+{% block content_header %}
+	<h1>Articles with tag {{ tag.name }}</h1>
+{% endblock %}
+
+{% block content_main %}
+	<div class="blogEntry">
+	<table>
+		<thead>
+			<tr>
+				<th>Article name</th>
+				<th>Article has also this tags</th>
+			</tr>
+		</thead>
+		<tbody>
+			{% for article in object_list %}
+			<tr>
+				<td><a href="{% url 'wiki_article' article %}">{{ article }}</a></td>
+				<td>{% include "wiki/inlines/tag_urls.html" %}
+				</td>
+			</tr>
+		</tbody>
+        {% endfor %}
+    </table>
+{% endblock %}
+

--- a/wiki/templates/wiki/tag_view.html
+++ b/wiki/templates/wiki/tag_view.html
@@ -8,7 +8,7 @@
 
 
 {% block content_header %}
-	<h1>Articles with tag {{ tag.name }}</h1>
+	<h1>Articles with tag '{{ tag.name }}'</h1>
 {% endblock %}
 
 {% block content_main %}

--- a/wiki/templates/wiki/tag_view.html
+++ b/wiki/templates/wiki/tag_view.html
@@ -17,7 +17,7 @@
 		<thead>
 			<tr>
 				<th>Article name</th>
-				<th>Article has also this tags</th>
+				<th>Also tagged with</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/wiki/templates/wiki/tag_view.html
+++ b/wiki/templates/wiki/tag_view.html
@@ -17,7 +17,7 @@
 		<thead>
 			<tr>
 				<th>Article name</th>
-				<th>Also tagged with</th>
+				<th>Tagged with</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -27,7 +27,7 @@
 				<td>{% include "wiki/inlines/tag_urls.html" %}</td>
 			</tr>
 		</tbody>
-        {% endfor %}
-    </table>
+			{% endfor %}
+	</table>
 {% endblock %}
 

--- a/wiki/templates/wiki/tag_view.html
+++ b/wiki/templates/wiki/tag_view.html
@@ -24,8 +24,7 @@
 			{% for article in object_list %}
 			<tr>
 				<td><a href="{% url 'wiki_article' article %}">{{ article }}</a></td>
-				<td>{% include "wiki/inlines/tag_urls.html" %}
-				</td>
+				<td>{% include "wiki/inlines/tag_urls.html" %}</td>
 			</tr>
 		</tbody>
         {% endfor %}

--- a/wiki/templates/wiki/view.html
+++ b/wiki/templates/wiki/view.html
@@ -47,7 +47,8 @@
 		<h2 class="errormessage">Outdated</h2>
 		<p class="errormessage">This article is marked as outdated.
 			If you are familiar with this topic, please consider updating and improving this page.
-			Afterwards remove the 'outdated' tag.</p>
+			In case of any questions, please ask in the forum! Notice the used <a href="{% url '/wiki/syntax' }">Sytnax</a> in our wiki.
+			After finishing your work remove the 'outdated' tag.</p>
 	{% endif %}
 	{% render_content article %}
 </div>

--- a/wiki/templates/wiki/view.html
+++ b/wiki/templates/wiki/view.html
@@ -1,6 +1,7 @@
 {% extends 'wiki/base.html' %}
 {% load i18n %}
 {% load wiki_extras %}
+{% load tagging_tags %}
 
 {% block title %}
 {{ article.title }} - {{block.super}}
@@ -47,10 +48,14 @@
 		<h2 class="errormessage">Outdated</h2>
 		<p class="errormessage">This article is marked as outdated.
 			If you are familiar with this topic, please consider updating and improving this page.
-			In case of any questions, please ask in the forum! Notice the used <a href="{% url '/wiki/syntax' }">Sytnax</a> in our wiki.
+			In case of any questions, please ask in the forum! For pointers see <a href="/wiki/WikiHelp">WikiHelp</a> in our wiki.
 			After finishing your work remove the 'outdated' tag.</p>
 	{% endif %}
 	{% render_content article %}
+	{% tags_for_object article as tag_list %}
+		{% if tag_list %}
+			<div class="right"> Tagged with: {% include "wiki/inlines/tag_urls.html" %}</div>
+		{% endif %}
 </div>
 {% endblock %}
 

--- a/wiki/templates/wiki/view.html
+++ b/wiki/templates/wiki/view.html
@@ -1,7 +1,6 @@
 {% extends 'wiki/base.html' %}
 {% load i18n %}
 {% load wiki_extras %}
-{% load tagging_tags %}
 
 {% block title %}
 {{ article.title }} - {{block.super}}
@@ -44,7 +43,6 @@
 			({% trans "Viewing revision " %} {{ revision }})
 		</p>
 	{% endif %}
-	{{ tag_list }}
 	{% if outdated %}
 		<h2 class="errormessage">Outdated</h2>
 		<p class="errormessage">This article is marked as outdated.

--- a/wiki/templates/wiki/view.html
+++ b/wiki/templates/wiki/view.html
@@ -54,7 +54,7 @@
 	{% render_content article %}
 	{% tags_for_object article as tag_list %}
 		{% if tag_list %}
-			<div class="right"> Tagged with: {% include "wiki/inlines/tag_urls.html" %}</div>
+			<div class="right">Tagged with: {% include "wiki/inlines/tag_urls.html" %}</div>
 		{% endif %}
 </div>
 {% endblock %}

--- a/wiki/templates/wiki/view.html
+++ b/wiki/templates/wiki/view.html
@@ -47,7 +47,7 @@
 		<h2 class="errormessage">Outdated</h2>
 		<p class="errormessage">This article is marked as outdated.
 			If you are familiar with this topic, please consider updating and improving this page.
-			Afterwards remove the 'oudated' tag.</p>
+			Afterwards remove the 'outdated' tag.</p>
 	{% endif %}
 	{% render_content article %}
 </div>

--- a/wiki/templates/wiki/view.html
+++ b/wiki/templates/wiki/view.html
@@ -1,6 +1,7 @@
 {% extends 'wiki/base.html' %}
 {% load i18n %}
 {% load wiki_extras %}
+{% load tagging_tags %}
 
 {% block title %}
 {{ article.title }} - {{block.super}}
@@ -42,6 +43,13 @@
 		<p class="small">
 			({% trans "Viewing revision " %} {{ revision }})
 		</p>
+	{% endif %}
+	{{ tag_list }}
+	{% if outdated %}
+		<h2 class="errormessage">Outdated</h2>
+		<p class="errormessage">This article is marked as outdated.
+			If you are familiar with this topic, please consider updating and improving this page.
+			Afterwards remove the 'oudated' tag.</p>
 	{% endif %}
 	{% render_content article %}
 </div>

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -99,7 +99,14 @@ urlpatterns = [
         views.backlinks,
         name="backlinks",
     ),
-    url(r'^tag_list/(?P<tag>[^/]+(?u))/$',
-        TaggedObjectList.as_view(model=Article, paginate_by=10, allow_empty=True, template_name="wiki/tag_view.html"),
-        name='article_tag_detail'),
+    url(
+        r"^tag_list/(?P<tag>[^/]+(?u))/$",
+        TaggedObjectList.as_view(
+            model=Article,
+            paginate_by=10,
+            allow_empty=True,
+            template_name="wiki/tag_view.html",
+        ),
+        name="article_tag_detail",
+    ),
 ]

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -103,7 +103,6 @@ urlpatterns = [
         r"^tag_list/(?P<tag>[^/]+(?u))/$",
         TaggedObjectList.as_view(
             model=Article,
-            paginate_by=10,
             allow_empty=True,
             template_name="wiki/tag_view.html",
         ),

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -11,6 +11,9 @@ from wiki.feeds import (
     RssArticleHistoryFeed,
     AtomArticleHistoryFeed,
 )
+from wiki.models import Article
+from tagging.views import TaggedObjectList
+
 
 urlpatterns = [
     # Redirects
@@ -96,4 +99,7 @@ urlpatterns = [
         views.backlinks,
         name="backlinks",
     ),
+    url(r'^tag_list/(?P<tag>[^/]+(?u))/$',
+        TaggedObjectList.as_view(model=Article, paginate_by=10, allow_empty=True, template_name="wiki/tag_view.html"),
+        name='article_tag_detail'),
 ]

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -27,6 +27,9 @@ from mainpage.templatetags.wl_markdown import do_wl_markdown
 from mainpage.wl_utils import get_real_ip
 from mainpage.wl_utils import get_valid_cache_key
 
+from tagging.models import Tag
+from tagging.views import TaggedObjectList
+
 import re
 import urllib.request, urllib.parse, urllib.error
 
@@ -226,11 +229,16 @@ def view_article(
             changeset = get_object_or_404(article.changeset_set, revision=revision)
             article.content = changeset.get_content()
 
+        outdated = False
+        tags = [x.name for x in Tag.objects.get_for_object(article)]
+        if "outdated" in tags:
+            outdated = True
         template_params = {
             "article": article,
             "revision": revision,
             "redirected_from": redirected_from,
             "allow_write": allow_write,
+            "outdated": outdated,
         }
 
         if notification is not None:

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -28,7 +28,6 @@ from mainpage.wl_utils import get_real_ip
 from mainpage.wl_utils import get_valid_cache_key
 
 from tagging.models import Tag
-from tagging.views import TaggedObjectList
 
 import re
 import urllib.request, urllib.parse, urllib.error


### PR DESCRIPTION
Fixes #323

The tagging app was already used by the wiki. What was missing were some views and modified html to make the tagging really useful.

* Added an input field `Tags` to a wiki edit page
* Show tags for each article on the index page
* Linkify tags and added a view to show all articles where this tag is used, also with additional tags related to the shown article(s)
* articles with tag 'outdated' gets an additional text on top

Sometimes the tags are displayed with an uppercase letter. Don't know why yet.

The used [tagging app](https://github.com/Fantomas42/django-tagging/blob/develop/docs/index.rst) looks not maintained anymore and it looks like it is [not ready for Django version > 4](https://github.com/Fantomas42/django-tagging/pull/23). Probably it is better to use [django-taggit](https://github.com/jazzband/django-taggit)?

Wiki Index with tags to each article, of course one article can have more than one tag:
![tagging_01](https://user-images.githubusercontent.com/6730556/208751417-c4211b1b-1db2-4e56-9eea-6855349a1b87.jpg)

All articles with tag 'atlanteans', one page has an additional tag 'Story':
![tagging_03](https://user-images.githubusercontent.com/6730556/208751660-ca2b3028-45f9-4bf0-a9c8-fbc7ae11c8b1.jpg)

Hint about outdated wiki page:
![tagging_04](https://user-images.githubusercontent.com/6730556/208752537-92ae77be-8f98-4a77-a52f-aa193d2712a3.jpg)
