### PR TITLE
Changed ccs for documentation warnings

### DIFF
--- a/documentation/styles/widelands.css
+++ b/documentation/styles/widelands.css
@@ -145,8 +145,8 @@ div.body h6 {
    padding: 3px 0 3px 10px;
 }
 
-div.body h1 { 
-   margin-top: 0; 
+div.body h1 {
+   margin-top: 0;
 }
 
 a.headerlink {
@@ -196,8 +196,7 @@ div.topic {
 }
 
 div.warning {
-   background-color: #ffe4e4;
-   border: 1px solid #f66;
+   border: 2px solid red;
 }
 
 p.admonition-title {


### PR DESCRIPTION
Fixes: #432 

Now, see: https://www.widelands.org/documentation/autogen_wl_ui/index.html#wl.ui.Panel.force_redraw

With this change the warning will be displayed like: 
![doc_Warning](https://github.com/widelands/widelands-website/assets/6730556/e2caefb4-27a9-49d2-816b-f6926378d7d2)
