### PR TITLE
fix aligning of table cells

### DIFF
--- a/mainpage/templatetags/wl_markdown.py
+++ b/mainpage/templatetags/wl_markdown.py
@@ -205,9 +205,10 @@ def find_smiley_Strings(bs4_string):
 
 # Predefine the markdown extensions here to have a clean code in
 # do_wl_markdown()
-md_extensions = ["extra", "toc", "mdx_wikilink_plus"]
+md_extensions = ["extra", "toc", "tables", "mdx_wikilink_plus"]
 md_configs = {
     "mdx_wikilink_plus": {"base_url": "/wiki/", "url_whitespace": "%20"},
+    "tables": {"use_align_attribute": "True"},
 }
 
 


### PR DESCRIPTION
fixes: https://www.widelands.org/forum/post/43060/

How it works: configure the table extension of python-markdown to use `align=xy` instead of `style="text-align: xy"`
