### PR TITLE
Fix the use of web chat in iframe

### DIFF
--- a/wlwebchat/templates/wlwebchat/index.html
+++ b/wlwebchat/templates/wlwebchat/index.html
@@ -18,7 +18,10 @@
     </p>
 
     <!-- Start of Webchat -->
-    <iframe src="https://web.libera.chat/gamja/?nick={% if user.is_authenticated %}{{ user.username }}{% else %}widelands_?{% endif %}#widelands" style="width: 100%; height: 610px;"></iframe>
+    <iframe src="https://web.libera.chat/?nick={% if user.is_authenticated %}{{ user.username }}{% else %}widelands_?{% endif %}#widelands"
+            style="width: 100%; height: 500px;"
+            referrerpolicy="origin">
+    </iframe>
     <!-- End of Webchat -->
 
     <p>


### PR DESCRIPTION
This fixes the web chat used on https://www.widelands.org/webchat/ by adding an other REFERRER POLICY to this particular iframe.

We are using the django default [referrer policy](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-referrer-policy) `same-origin` which prevent's showing the content of other sites  in an iframe.

Must be tested on the server.

Reference: https://github.com/Libera-Chat/libera-chat.github.io/issues/396