### PR TITLE
fix wlprofile tabs for addon settings

### DIFF
--- a/wladdons_settings/views.py
+++ b/wladdons_settings/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from wladdons_settings.models import AddonNoticeType
 from wladdons_settings.models import get_addon_usersetting
 from wladdons_settings.models import get_addons_for_user
-
+from django.utils.connection import ConnectionDoesNotExist
 from django.contrib.auth.decorators import login_required
 
 
@@ -28,7 +28,11 @@ def addon_settings(request):
             else:
                 settings.append(usersetting)
 
-    addons = get_addons_for_user(request.user.pk)
+    try:
+        addons = get_addons_for_user(request.user.pk)
+    except ConnectionDoesNotExist:
+        addons = None
+
     return render(
         request,
         "wladdons_settings/settings.html",

--- a/wlprofile/templates/wlprofile/base.html
+++ b/wlprofile/templates/wlprofile/base.html
@@ -33,12 +33,9 @@
 		<li>
 			<a {% block notifications %}{% endblock %} href="{% url 'notification_notices' %}">Notification Settings</a>
 		</li>
-		<!-- TODO: remove this if, otherwise the tab isn't shown when switching tabs -->
-		{% if addondb %}
 		<li>
 			<a {% block addon_settings %}{% endblock %} href="{% url 'addon_settings' %}">Add-On Settings</a>
 		</li>
-		{% endif %}
 		<li>
 			<a {% block game_passwrd %}{% endblock %} href="{% url 'wlggz_changepw' %}" title="Online Gaming Password">Gaming Password</a>
 		</li>


### PR DESCRIPTION
Fixes vanishing the tab for add-on settings if other tabs are active in wlprofile.

Now the tab "Add-on Settings" is always shown.