### PR TITLE
fixed note for uploading maps

### DIFF
--- a/wlmaps/templates/wlmaps/map_list.html
+++ b/wlmaps/templates/wlmaps/map_list.html
@@ -55,11 +55,9 @@
 <section class="blogEntry">
     <p>
         <span class="errormessage">Please note:</span> Uploading maps on the website
-        which use terrains
-        from add-ons will not work! Starting with Widelands version 1.0 it is
-        recommended to upload new
-        maps within the game as an add-on. To do so start the "Add-Ons Packager" via
-        "Main menu → Add-Ons → Tab Development → Launch the add-ons packager".
+        which use terrains from add-ons will not work! Starting with Widelands version 1.2
+        you can publish your map as an add-on directly from the Editor by using the menu entry
+        "Publish Map Online…" in the main menu.
     </p>
     <p>
         The map files have to be placed in the Widelands map directory to be found by


### PR DESCRIPTION
Since 1.2 one can upload a map as an add-on within the widelands map editor. No need to start the add-ons manager.