### PR TITLE
restrict wiki edits

### DIFF
--- a/wiki/templates/wiki/base.html
+++ b/wiki/templates/wiki/base.html
@@ -19,15 +19,19 @@ We disable or change them in the subpages. #}
 {% block content_tabbing %}
 <ul class="small tab-list"{% block style_tab_list %}{% endblock %}>
 	{% if article.id %}
-		<li>
+    {% if perms.wiki.can_change %}
+        <li>
 			<a {% block class_wiki_edit %}{% endblock %} href="{% url 'wiki_edit' article.title %}">{% trans "Edit this article" %}</a>
 		</li>
+    {% endif %}
 		<li>
 			<a {% block class_wiki_back %}{% endblock %}href="{% url 'wiki_article' article.title %}">{% trans "Back to article" %}</a>
 		</li>
+    {% if perms.wiki.can_change %}
 		<li>
 			<a {% block class_wiki_hist %}{% endblock %} href="{% url 'wiki_article_history' article.title %}">{% trans "History" %}</a>
 		</li>
+    {% endif %}
 		<li>
 			<a {% block class_wiki_backl %}{% endblock %} href="{% url 'backlinks' article.title %}">{% trans "Backlinks" %}</a>
 		</li>

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -303,7 +303,7 @@ def edit_article(
     *args,
     **kw,
 ):
-    if not request.user.has_perm('wiki.change_article'):
+    if not request.user.has_perm("wiki.change_article"):
         return HttpResponseForbidden()
 
     group = None
@@ -618,7 +618,7 @@ def revert_to_revision(
     *args,
     **kw,
 ):
-    if not request.user.has_perm('wiki.change_article'):
+    if not request.user.has_perm("wiki.change_article"):
         return HttpResponseForbidden()
 
     if request.method == "POST":

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -303,6 +303,9 @@ def edit_article(
     *args,
     **kw,
 ):
+    if not request.user.has_perm('wiki.change_article'):
+        return HttpResponseForbidden()
+
     group = None
     article_args = {"title": title}
     if group_slug is not None:
@@ -615,6 +618,9 @@ def revert_to_revision(
     *args,
     **kw,
 ):
+    if not request.user.has_perm('wiki.change_article'):
+        return HttpResponseForbidden()
+
     if request.method == "POST":
         revision = int(request.POST["revision"])
 


### PR DESCRIPTION
This is a temporary solution to prevent wiki edits. Only superusers can edit wiki articles with this change.

Not ideal, but a fast and dirty solution...