### PR TITLE
Fix wiki feed with no user

### DIFF
--- a/wiki/feeds.py
+++ b/wiki/feeds.py
@@ -14,9 +14,7 @@ class RssHistoryFeed(Feed):
     description_template = "wiki/feeds/history_description.html"
 
     def items(self):
-        return ChangeSet.objects.exclude(article__deleted=True).order_by("-modified")[
-            :30
-        ]
+        return ChangeSet.official.order_by("-modified")[:30]
 
     def item_pubdate(self, item):
         """Return the item's pubdate.

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -140,6 +140,7 @@ class ChangeSetManager(models.Manager):
 
 class ChangeSetOfficial(models.Manager):
     def get_queryset(self):
+        """Return a queryset which contains data for the public."""
         return super().get_queryset().exclude(article__deleted=True).exclude(editor=None)
 
 

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -138,6 +138,11 @@ class ChangeSetManager(models.Manager):
         return self.filter(revision__gt=int(revision))
 
 
+class ChangeSetOfficial(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().exclude(article__deleted=True).exclude(editor=None)
+
+
 class ChangeSet(models.Model):
     """A report of an older version of some Article."""
 
@@ -169,6 +174,7 @@ class ChangeSet(models.Model):
     reverted = models.BooleanField(_("Reverted Revision"), default=False)
 
     objects = ChangeSetManager()
+    official = ChangeSetOfficial()
 
     class Meta:
         verbose_name = _("Change set")

--- a/wiki/templates/wiki/history.html
+++ b/wiki/templates/wiki/history.html
@@ -80,7 +80,6 @@
 		</thead>
 		<tbody>
 		{% for change in changes %}
-			{% if change.editor %}
 			<tr class="{% cycle 'odd' 'even' %}">
 				<td class="small_column">
 					<a href="{{ change.get_absolute_url }}">{{ change.revision }}</a>
@@ -110,7 +109,6 @@
 					{% if change.comment %}'{{ change.comment }}'{% endif %}
 				</td>
 			</tr>
-			{% endif %}
 		{% endfor %}
 		</tbody>
 		</table>

--- a/wiki/templates/wiki/recentchanges.html
+++ b/wiki/templates/wiki/recentchanges.html
@@ -33,7 +33,6 @@
                 <th class="comment">{% trans "Comment" %}</th>
             </tr>
         {% endifchanged %}
-            {% if change.editor %}
             <tr class="{% cycle 'odd' 'even' %}">
                 <td>
                     {% if change.old_title %}
@@ -53,7 +52,6 @@
                 <td>{{ change.editor|user_link }}</td>
                 <td>{{ change.comment }}</td>
             </tr>
-            {% endif %}
             {% endfor %}
         </table>
 

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -685,8 +685,6 @@ def history(
         if not allow_read:
             return HttpResponseForbidden()
 
-        changes_qs = changes_qs.exclude(article__deleted=True)
-
         template_params = {
             "changes": changes_qs.order_by("-modified"),
             "allow_write": allow_write,

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -46,6 +46,7 @@ except ImportError:
 # default querysets
 ALL_ARTICLES = Article.objects.all()
 ALL_CHANGES = ChangeSet.objects.all()
+OFFICIAL_CHANGES = ChangeSet.official.all()
 
 
 def get_redirect(article):
@@ -663,7 +664,7 @@ def history(
     group_slug_field=None,
     group_qs=None,
     article_qs=ALL_ARTICLES,
-    changes_qs=ALL_CHANGES,
+    changes_qs=OFFICIAL_CHANGES,
     template_name="recentchanges.html",
     template_dir="wiki",
     extra_context=None,

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -580,7 +580,7 @@ def article_history(
 
         # changes = article.changeset_set.filter(
         #    reverted=False).order_by('-revision')
-        changes = article.changeset_set.all().order_by("-revision")
+        changes = article.changeset_set(manager="official").order_by("-revision")
 
         template_params = {
             "article": article,


### PR DESCRIPTION
Fixes  #481 #CB397

Added a new model manager which returns only official changesets. Official means:

- without deleted articles (used in https://www.widelands.org/wiki/history/)
- without changesets whose user is None. This can happen if a spammer get deleted

Adapted views and templates.